### PR TITLE
docs: MkDocs site with Material theme and GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra docs --python 3.12
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# MkDocs build output
+site/

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,8 +86,7 @@ first that validates.
 **Raises:**
 
 - `ExtractionError` -- no YAML blocks found or none
-  validate
-- `ImportError` -- if `pyyaml` is not installed
+  validate, or if `pyyaml` is not installed
 
 ---
 
@@ -106,7 +105,7 @@ blocks (JSON/YAML) first, then falls back to tables.
 **Returns:**
 
 - `T` for a single code block match (when `partial=False`)
-- `list[T]` for table or JSON array match
+- `list[T]` for table, JSON array, or YAML array match
   (when `partial=False`)
 - `PartialResult[T]` when `partial=True`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,197 @@
+# API Reference
+
+## MDConverter
+
+```python
+from md2pydantic import MDConverter
+```
+
+### `MDConverter(model)`
+
+Create a converter bound to a Pydantic v2 `BaseModel`
+subclass.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | `type[T]` | A Pydantic `BaseModel` subclass |
+
+**Raises:**
+
+- `TypeError` -- if `model` is not a `BaseModel` subclass
+
+---
+
+### `parse_tables(markdown, *, index=None, heading=None, partial=False)`
+
+Extract Markdown tables and return validated model instances.
+
+**Parameters:**
+
+| Parameter  | Type            | Default | Description |
+|------------|-----------------|---------|-------------|
+| `markdown` | `str`           | --      | Markdown text to parse |
+| `index`    | `int \| None`   | `None`  | 0-based table index (applied after heading filter) |
+| `heading`  | `str \| None`   | `None`  | Substring to match against table headings (case-insensitive) |
+| `partial`  | `bool`          | `False` | Return `PartialResult` instead of raising on failure |
+
+**Returns:**
+
+- `list[T]` when `partial=False`
+- `PartialResult[T]` when `partial=True`
+
+**Raises:**
+
+- `ExtractionError` -- no tables found or no rows validate
+  (only when `partial=False`)
+
+---
+
+### `parse_json(markdown)`
+
+Extract a JSON code block and return a validated model.
+Tries each JSON block in document order, returning the
+first that validates.
+
+**Parameters:**
+
+| Parameter  | Type  | Description |
+|------------|-------|-------------|
+| `markdown` | `str` | Markdown text to parse |
+
+**Returns:** `T` (single model instance)
+
+**Raises:**
+
+- `ExtractionError` -- no JSON blocks found or none
+  validate
+
+---
+
+### `parse_yaml(markdown)`
+
+Extract a YAML code block and return a validated model.
+Tries each YAML block in document order, returning the
+first that validates.
+
+**Parameters:**
+
+| Parameter  | Type  | Description |
+|------------|-------|-------------|
+| `markdown` | `str` | Markdown text to parse |
+
+**Returns:** `T` (single model instance)
+
+**Raises:**
+
+- `ExtractionError` -- no YAML blocks found or none
+  validate
+- `ImportError` -- if `pyyaml` is not installed
+
+---
+
+### `parse(markdown, *, partial=False)`
+
+Auto-detect format and parse structured data. Tries code
+blocks (JSON/YAML) first, then falls back to tables.
+
+**Parameters:**
+
+| Parameter  | Type   | Default | Description |
+|------------|--------|---------|-------------|
+| `markdown` | `str`  | --      | Markdown text to parse |
+| `partial`  | `bool` | `False` | Return `PartialResult` instead of raising on failure |
+
+**Returns:**
+
+- `T` for a single code block match (when `partial=False`)
+- `list[T]` for table or JSON array match
+  (when `partial=False`)
+- `PartialResult[T]` when `partial=True`
+
+**Raises:**
+
+- `ExtractionError` -- no structured data found or none
+  validates (only when `partial=False`)
+
+---
+
+## Exceptions
+
+```python
+from md2pydantic import (
+    ExtractionError,
+    MD2PydanticError,
+)
+```
+
+### `MD2PydanticError`
+
+Base exception for all md2pydantic errors. Inherits from
+`Exception`.
+
+### `ExtractionError`
+
+Raised when structured data cannot be extracted or
+validated. Inherits from `MD2PydanticError`.
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `errors` | `list[TransformError \| ModelValidationError]` | Typed error details with source locations |
+
+Calling `str()` on an `ExtractionError` produces a
+numbered, human-readable summary.
+
+---
+
+## Result Types
+
+```python
+from md2pydantic import PartialResult, FieldError
+```
+
+### `PartialResult[T]`
+
+Contains both successfully parsed items and errors.
+
+| Attribute    | Type | Description |
+|--------------|------|-------------|
+| `data`       | `list[T]` | Valid model instances |
+| `errors`     | `list[TransformError \| ModelValidationError]` | Errors from failed items |
+| `has_errors` | `bool` (property) | `True` if any items failed |
+
+### `FieldError`
+
+A single field-level validation error.
+
+| Attribute     | Type  | Description |
+|---------------|-------|-------------|
+| `field`       | `str` | Field name that failed |
+| `message`     | `str` | Pydantic error message |
+| `input_value` | `Any` | Value that was rejected |
+| `error_type`  | `str` | Pydantic error type string |
+
+### `TransformError`
+
+Error from the transform phase (JSON/YAML parsing failed).
+
+| Attribute     | Type            | Description |
+|---------------|-----------------|-------------|
+| `phase`       | `"transform"`   | Always `"transform"` |
+| `message`     | `str`           | Error description |
+| `location`    | `BlockLocation` | Source location |
+| `raw_content` | `str`           | Original block text |
+
+### `ModelValidationError`
+
+Error from the validation phase (Pydantic rejected data).
+
+| Attribute      | Type | Description |
+|----------------|------|-------------|
+| `phase`        | `"validate"` | Always `"validate"` |
+| `field_errors` | `tuple[FieldError, ...]` | Per-field errors |
+| `location`     | `BlockLocation \| RowLocation` | Source location |
+| `raw_input`    | `dict[str, Any]` | Dict passed to Pydantic |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture
+
+md2pydantic follows a **Seek, Clean, Validate** pipeline.
+Each stage is handled by a dedicated module.
+
+## Pipeline
+
+```
+Markdown input
+    │
+    ▼
+┌──────────┐
+│ Scanner  │  Identify candidate blocks
+└────┬─────┘
+     │
+     ▼
+┌──────────────┐
+│ Transformer  │  Convert to Python dicts
+└────┬─────────┘
+     │
+     ▼
+┌───────────┐
+│ Validator │  Validate against Pydantic model
+└────┬──────┘
+     │
+     ▼
+Typed model instances
+```
+
+## Stage 1: Scanner
+
+**Module:** `parser.py`
+
+Uses regex and heuristics to identify candidate blocks
+within the Markdown input:
+
+- Fenced code blocks (` ```json `, ` ```yaml `)
+- Inline JSON objects (`{...}`)
+- Pipe-delimited Markdown tables
+
+Handles LLM-specific quirks like unclosed fences, trailing
+prose, extra backticks, tilde fences (`~~~`), and nested
+structures.
+
+**Output:** `CodeBlock` or `TableBlock` objects with content
+and source location metadata.
+
+## Stage 2: Transformer
+
+**Module:** `transformers.py`
+
+Converts raw extracted content into Python dictionaries:
+
+- **JSON blocks** -- parses JSON with recovery for trailing
+  commas, single quotes, unquoted keys, and truncated
+  output
+- **YAML blocks** -- parses YAML via `pyyaml`
+- **Tables** -- converts rows to dicts using headers as keys
+
+Also performs pre-processing: boolean word mapping
+(Yes/No to True/False) and null sentinel replacement.
+
+**Output:** Python `dict` objects ready for Pydantic.
+
+## Stage 3: Validator
+
+**Module:** `validators.py`
+
+Passes dictionaries to the user-defined Pydantic v2 model.
+Leverages Pydantic's native type coercion (str to int, str
+to float, str to datetime, etc.).
+
+Returns either a validated model instance or structured
+error details with field-level information.
+
+**Output:** `ValidationResult` with typed data or errors.
+
+## Orchestrator
+
+**Module:** `converter.py`
+
+`MDConverter` is the public API that orchestrates the full
+pipeline. It is the only class users interact with
+directly.
+
+## Module Map
+
+| Module            | Role                          |
+|-------------------|-------------------------------|
+| `converter.py`    | Public API (`MDConverter`)    |
+| `parser.py`       | Block detection and scanning  |
+| `transformers.py` | Raw content to Python dicts   |
+| `validators.py`   | Pydantic model validation     |
+| `models.py`       | Internal types and exceptions |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,0 +1,50 @@
+# Supported Formats
+
+## Overview
+
+| Format          | Method           | Fenced | Inline | Recovery |
+|-----------------|------------------|--------|--------|----------|
+| Markdown tables | `parse_tables()` | --     | Yes    | Padded/truncated columns |
+| JSON            | `parse_json()`   | Yes    | Yes    | Trailing commas, single quotes, unquoted keys, truncated JSON |
+| YAML            | `parse_yaml()`   | Yes    | --     | --       |
+| Auto-detect     | `parse()`        | Yes    | Yes    | All of the above |
+
+## Markdown Tables
+
+Pipe-delimited tables with a header row and separator row.
+Surrounding prose is ignored. The parser handles:
+
+- Extra whitespace in cells
+- Missing or extra trailing pipes
+- Padded or truncated columns (mismatched column counts)
+
+## JSON
+
+Both fenced (` ```json `) and inline `{...}` blocks are
+detected. Recovery features fix common LLM quirks:
+
+- **Trailing commas** -- `{"a": 1,}` becomes `{"a": 1}`
+- **Single quotes** -- `{'a': 1}` becomes `{"a": 1}`
+- **Unquoted keys** -- `{a: 1}` becomes `{"a": 1}`
+- **Truncated JSON** -- `{"a": 1` gets its closing bracket
+
+## YAML
+
+Only fenced (` ```yaml `) blocks are supported. Inline
+YAML is not detected due to ambiguity with plain prose.
+
+Requires the `pyyaml` package:
+
+```bash
+pip install md2pydantic[yaml]
+```
+
+## Auto-Detect
+
+The `parse()` method tries formats in this order:
+
+1. Code blocks (JSON and YAML) -- higher confidence signal
+2. Markdown tables -- fallback
+
+The first block that validates against the target model is
+returned.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+## Requirements
+
+- Python 3.10 or later
+- Pydantic v2
+
+## Installation
+
+=== "pip"
+
+    ```bash
+    pip install md2pydantic
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add md2pydantic
+    ```
+
+### Optional Extras
+
+```bash
+pip install md2pydantic[yaml]    # YAML support (pyyaml)
+pip install md2pydantic[pandas]  # DataFrame conversion
+```
+
+## Complete Example
+
+Define a Pydantic model whose field names match the table
+headers exactly (case-sensitive):
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class Product(BaseModel):
+    name: str
+    price: float
+    in_stock: bool
+
+markdown = """
+Here are the products currently available:
+
+| name       | price | in_stock |
+|------------|-------|----------|
+| Widget     | 9.99  | Yes      |
+| Gadget     | 24.50 | No       |
+| Doohickey  | 3.75  | Yes      |
+"""
+
+products = MDConverter(Product).parse_tables(markdown)
+```
+
+## Understanding the Output
+
+`parse_tables` returns a `list` of validated model instances,
+one per table row:
+
+```python
+for p in products:
+    print(f"{p.name}: ${p.price} (in stock: {p.in_stock})")
+
+# Widget: $9.99 (in stock: True)
+# Gadget: $24.5 (in stock: False)
+# Doohickey: $3.75 (in stock: True)
+```
+
+Type coercion happens automatically:
+
+- `"9.99"` (string in Markdown) becomes `9.99` (`float`)
+- `"Yes"` / `"No"` become `True` / `False` (`bool`)
+
+Pydantic handles numeric coercion. md2pydantic handles
+boolean word mapping before passing data to Pydantic.
+
+## Next Steps
+
+- [Markdown Tables](guide/tables.md) -- table parsing details
+- [JSON Blocks](guide/json.md) -- extract JSON from Markdown
+- [YAML Blocks](guide/yaml.md) -- extract YAML from Markdown
+- [Auto-Detect](guide/auto-detect.md) -- let md2pydantic
+  choose the format
+- [Error Handling](guide/error-handling.md) -- handle
+  extraction failures

--- a/docs/guide/auto-detect.md
+++ b/docs/guide/auto-detect.md
@@ -37,6 +37,7 @@ The return type depends on the detected format:
 | JSON object    | `T` (single instance) |
 | YAML object    | `T` (single instance) |
 | JSON array     | `list[T]` |
+| YAML array     | `list[T]` |
 | Markdown table | `list[T]` |
 
 ## When to Use `parse()` vs Specific Methods

--- a/docs/guide/auto-detect.md
+++ b/docs/guide/auto-detect.md
@@ -1,0 +1,56 @@
+# Auto-Detect
+
+## Usage
+
+The `parse()` method automatically detects the format of
+structured data in the Markdown input:
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class Item(BaseModel):
+    name: str
+    quantity: int
+
+result = MDConverter(Item).parse(markdown)
+```
+
+## Detection Priority
+
+`parse()` follows this order:
+
+1. **Code blocks** (JSON and YAML) -- scanned first because
+   fenced blocks are a stronger signal of structure.
+2. **Tables** -- used as a fallback when no code blocks
+   match the model.
+
+Within code blocks, all blocks are tried in document order.
+The first block that validates against the model wins.
+
+## Return Type
+
+The return type depends on the detected format:
+
+| Detected format | Return type |
+|----------------|-------------|
+| JSON object    | `T` (single instance) |
+| YAML object    | `T` (single instance) |
+| JSON array     | `list[T]` |
+| Markdown table | `list[T]` |
+
+## When to Use `parse()` vs Specific Methods
+
+Use `parse()` when:
+
+- You do not know the format in advance
+- The input could be either a code block or a table
+
+Use `parse_tables()`, `parse_json()`, or `parse_yaml()`
+when:
+
+- You know the exact format and want to enforce it
+- You need table-specific parameters like `heading` or
+  `index`
+- You want a predictable return type (`list[T]` for tables,
+  `T` for code blocks)

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -1,0 +1,79 @@
+# Error Handling
+
+## ExtractionError
+
+When md2pydantic cannot extract valid data, it raises
+`ExtractionError`:
+
+```python
+from md2pydantic import MDConverter, ExtractionError
+
+try:
+    result = MDConverter(MyModel).parse_tables(
+        "no tables here"
+    )
+except ExtractionError as e:
+    print(e)         # Human-readable summary
+    print(e.errors)  # List of typed error details
+```
+
+`ExtractionError` is raised when:
+
+- No structured data is found in the input
+- Structured data is found but none validates against
+  the model
+
+## The `.errors` Attribute
+
+Each entry in `e.errors` is one of two types:
+
+### TransformError
+
+Raised during the parsing phase when raw content cannot be
+converted to a Python dictionary. Contains:
+
+- `phase` -- always `"transform"`
+- `message` -- description of what went wrong
+- `location` -- `BlockLocation` with line numbers
+- `raw_content` -- the original block text
+
+### ModelValidationError
+
+Raised during the validation phase when Pydantic rejects
+the data. Contains:
+
+- `phase` -- always `"validate"`
+- `field_errors` -- tuple of `FieldError` objects
+- `location` -- `BlockLocation` or `RowLocation`
+- `raw_input` -- the dict that was passed to Pydantic
+
+Each `FieldError` has:
+
+- `field` -- the field name that failed
+- `message` -- Pydantic's error message
+- `input_value` -- the value that was rejected
+- `error_type` -- Pydantic's error type string
+
+## Exception Hierarchy
+
+```
+Exception
+  └── MD2PydanticError
+        └── ExtractionError
+```
+
+You can catch `MD2PydanticError` to handle all library
+exceptions, or `ExtractionError` for extraction-specific
+failures.
+
+## Human-Readable Output
+
+Calling `str()` on an `ExtractionError` produces a
+numbered summary:
+
+```
+No table rows matched the model
+  [1] Validation error in table 0, row 0: age: Input
+      should be a valid integer; active: Input should
+      be a valid boolean
+```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,45 @@
+# User Guide
+
+md2pydantic supports three input formats, each with a
+dedicated parsing method.
+
+## Markdown Tables
+
+Pipe-delimited tables are parsed row-by-row into a list of
+model instances. Headers become field names.
+
+See [Markdown Tables](tables.md).
+
+## JSON Blocks
+
+Fenced (` ```json `) and inline `{...}` JSON blocks are
+extracted and validated. Includes recovery for common LLM
+quirks like trailing commas and unquoted keys.
+
+See [JSON Blocks](json.md).
+
+## YAML Blocks
+
+Fenced (` ```yaml `) blocks are extracted and validated.
+Requires the `pyyaml` dependency.
+
+See [YAML Blocks](yaml.md).
+
+## Auto-Detect
+
+The `parse()` method tries code blocks first, then falls
+back to tables. Use it when you do not know the format
+in advance.
+
+See [Auto-Detect](auto-detect.md).
+
+## Additional Topics
+
+- [Table Selection](table-selection.md) -- filter tables
+  by heading or index
+- [Null Sentinels](null-sentinels.md) -- handle missing
+  values gracefully
+- [Error Handling](error-handling.md) -- structured error
+  reporting
+- [Partial Results](partial-results.md) -- get valid rows
+  even when some fail

--- a/docs/guide/json.md
+++ b/docs/guide/json.md
@@ -1,0 +1,63 @@
+# JSON Blocks
+
+## Fenced JSON
+
+Extract JSON from a fenced code block:
+
+````python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class ServerConfig(BaseModel):
+    host: str
+    port: int
+    debug: bool
+
+markdown = '''Here is the config:
+
+```json
+{
+    "host": "localhost",
+    "port": 8080,
+    "debug": true
+}
+```
+'''
+
+config = MDConverter(ServerConfig).parse_json(markdown)
+# ServerConfig(host='localhost', port=8080, debug=True)
+````
+
+!!! note
+    `parse_json` returns a **single** model instance, not
+    a list. It tries each JSON block in document order and
+    returns the first one that validates.
+
+## Inline JSON
+
+md2pydantic also detects inline (unfenced) JSON objects:
+
+```python
+markdown = """
+The server config is {"host": "localhost", "port": 8080,
+"debug": true} as specified.
+"""
+
+config = MDConverter(ServerConfig).parse_json(markdown)
+```
+
+## Recovery Features
+
+LLM output often contains malformed JSON. md2pydantic
+attempts to fix these issues automatically:
+
+| Issue              | Example                | Recovery          |
+|--------------------|------------------------|-------------------|
+| Trailing commas    | `{"a": 1,}`           | Comma removed     |
+| Single quotes      | `{'a': 1}`            | Replaced with `"` |
+| Unquoted keys      | `{host: "localhost"}`  | Keys quoted       |
+| Truncated JSON     | `{"a": 1, "b": 2`     | Brackets closed   |
+
+!!! tip
+    Recovery is best-effort. If the JSON is too malformed
+    to salvage, an `ExtractionError` is raised.

--- a/docs/guide/null-sentinels.md
+++ b/docs/guide/null-sentinels.md
@@ -1,0 +1,51 @@
+# Null Sentinels
+
+md2pydantic recognizes common placeholder values in table
+cells and converts them to `None` for optional fields.
+
+## Example
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class Employee(BaseModel):
+    name: str
+    department: str
+    salary: float | None = None
+
+markdown = """
+| name  | department  | salary |
+|-------|-------------|--------|
+| Alice | Engineering | 95000  |
+| Bob   | Marketing   | N/A    |
+| Carol | Sales       | -      |
+"""
+
+employees = MDConverter(Employee).parse_tables(markdown)
+# employees[0].salary == 95000.0
+# employees[1].salary is None  (from "N/A")
+# employees[2].salary is None  (from "-")
+```
+
+## Recognized Sentinels
+
+The following values are treated as `None`:
+
+| Sentinel | Example cell |
+|----------|-------------|
+| Empty    | `\|  \|`      |
+| `N/A`    | `\| N/A \|`  |
+| `NA`     | `\| NA \|`   |
+| `null`   | `\| null \|` |
+| `-`      | `\| - \|`    |
+| `--`     | `\| -- \|`  |
+
+Matching is **case-insensitive**: `n/a`, `N/A`, `Null`,
+and `NULL` are all treated the same.
+
+!!! warning
+    The target field **must** be `Optional` (e.g.,
+    `float | None = None`). If a sentinel value appears
+    in a required field, Pydantic will raise a validation
+    error.

--- a/docs/guide/null-sentinels.md
+++ b/docs/guide/null-sentinels.md
@@ -39,7 +39,7 @@ The following values are treated as `None`:
 | `NA`     | `\| NA \|`   |
 | `null`   | `\| null \|` |
 | `-`      | `\| - \|`    |
-| `--`     | `\| -- \|`  |
+| `—`      | `\| — \|`  |
 
 Matching is **case-insensitive**: `n/a`, `N/A`, `Null`,
 and `NULL` are all treated the same.

--- a/docs/guide/partial-results.md
+++ b/docs/guide/partial-results.md
@@ -1,0 +1,72 @@
+# Partial Results
+
+By default, `parse_tables` raises `ExtractionError` if
+**no** rows validate. But when some rows are valid and
+others are not, all valid rows are still returned.
+
+Use `partial=True` when you want access to **both** the
+valid rows and the errors for invalid rows.
+
+## Usage
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter, PartialResult
+
+class User(BaseModel):
+    name: str
+    age: int
+    active: bool
+
+markdown = """
+| name  | age     | active |
+|-------|---------|--------|
+| Alice | 30      | Yes    |
+| Bob   | unknown | No     |
+| Carol | 28      | Yes    |
+"""
+
+result = MDConverter(User).parse_tables(
+    markdown, partial=True
+)
+```
+
+## The PartialResult Object
+
+`PartialResult` contains:
+
+- `result.data` -- list of valid model instances
+- `result.errors` -- list of `TransformError` or
+  `ModelValidationError` objects
+- `result.has_errors` -- `True` if any rows failed
+
+```python
+print(len(result.data))    # 2 (Alice and Carol)
+print(result.has_errors)   # True (Bob failed)
+
+for err in result.errors:
+    print(err)
+```
+
+## When to Use Partial Results
+
+Partial results are useful when:
+
+- You are processing LLM output that may contain some
+  invalid rows mixed with valid data
+- You want to log errors without losing the good data
+- You need to report which specific rows failed and why
+
+## Supported Methods
+
+`partial=True` is supported on:
+
+- `parse_tables()` -- errors are per-row
+- `parse()` -- errors are per-block or per-row depending
+  on the detected format
+
+!!! note
+    `parse_json()` and `parse_yaml()` do not support
+    `partial` because they return a single model instance.
+    Use `parse(partial=True)` if you need partial-result
+    semantics with code blocks.

--- a/docs/guide/table-selection.md
+++ b/docs/guide/table-selection.md
@@ -1,0 +1,70 @@
+# Table Selection
+
+When a Markdown document contains multiple tables, you can
+select specific ones using the `heading` and `index`
+parameters.
+
+## Filter by Heading
+
+Use `heading=` to select tables that appear under a matching
+Markdown heading:
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class User(BaseModel):
+    name: str
+    age: int
+    active: bool
+
+markdown = """
+## Current Staff
+
+| name  | age | active |
+|-------|-----|--------|
+| Alice | 30  | Yes    |
+
+## Former Staff
+
+| name  | age | active |
+|-------|-----|--------|
+| Bob   | 25  | No     |
+| Eve   | 35  | No     |
+"""
+
+current = MDConverter(User).parse_tables(
+    markdown, heading="Current Staff"
+)
+# [User(name='Alice', age=30, active=True)]
+
+former = MDConverter(User).parse_tables(
+    markdown, heading="Former Staff"
+)
+# [User(name='Bob', age=25, active=False),
+#  User(name='Eve', age=35, active=False)]
+```
+
+Heading matching is **case-insensitive** and supports
+**substring** matches. For example, `heading="current"`
+would also match the heading `## Current Staff`.
+
+## Filter by Index
+
+Use `index=` to select a table by its 0-based position:
+
+```python
+first_table = MDConverter(User).parse_tables(
+    markdown, index=0
+)
+second_table = MDConverter(User).parse_tables(
+    markdown, index=1
+)
+```
+
+!!! note
+    When both `heading` and `index` are provided, the
+    heading filter is applied first, then the index selects
+    among the filtered results. So `heading="Staff",
+    index=0` returns the first table under any heading
+    containing "Staff".

--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -1,0 +1,74 @@
+# Markdown Tables
+
+## Basic Usage
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class User(BaseModel):
+    name: str
+    age: int
+    active: bool
+
+markdown = """
+| name  | age | active |
+|-------|-----|--------|
+| Alice | 30  | Yes    |
+| Bob   | 25  | No     |
+"""
+
+users = MDConverter(User).parse_tables(markdown)
+# [User(name='Alice', age=30, active=True),
+#  User(name='Bob', age=25, active=False)]
+```
+
+!!! note
+    `parse_tables` always returns a **list** of model
+    instances, even if the table has only one row.
+
+## Header-to-Field Mapping
+
+Table headers are mapped to model fields by exact name
+match. The mapping is **case-sensitive**: a header `Name`
+will not match a field named `name`.
+
+```
+| name | age |    <-- must match field names exactly
+|------|-----|
+| ...  | ... |
+```
+
+## Bool Coercion
+
+md2pydantic maps common boolean words to `True`/`False`
+before passing data to Pydantic. The mapping is
+case-insensitive:
+
+| Input values          | Result  |
+|-----------------------|---------|
+| Yes, Y, true, on, 1  | `True`  |
+| No, N, false, off, 0  | `False` |
+
+This only applies to fields typed as `bool`.
+
+## Whitespace Handling
+
+Leading and trailing whitespace in cell values is stripped
+automatically. This means `| Alice |` and `|Alice|` both
+produce `"Alice"`.
+
+## Surrounding Prose
+
+md2pydantic ignores prose before and after the table. LLM
+output like this works fine:
+
+```markdown
+Here are the results I found:
+
+| name  | age |
+|-------|-----|
+| Alice | 30  |
+
+Let me know if you need anything else!
+```

--- a/docs/guide/yaml.md
+++ b/docs/guide/yaml.md
@@ -1,0 +1,47 @@
+# YAML Blocks
+
+## Fenced YAML
+
+Extract YAML from a fenced code block:
+
+````python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class ServerConfig(BaseModel):
+    host: str
+    port: int
+    debug: bool
+
+markdown = '''Here is your config:
+
+```yaml
+host: api.example.com
+port: 443
+debug: false
+```
+'''
+
+config = MDConverter(ServerConfig).parse_yaml(markdown)
+# ServerConfig(host='api.example.com', port=443, debug=False)
+````
+
+!!! warning
+    YAML support requires `pyyaml`. Install it with:
+
+    ```bash
+    pip install md2pydantic[yaml]
+    ```
+
+    An `ImportError` is raised at parse time if `pyyaml`
+    is not installed.
+
+!!! note
+    `parse_yaml` returns a **single** model instance. It
+    tries each YAML block in document order and returns the
+    first one that validates.
+
+## Inline YAML
+
+Inline (unfenced) YAML is not supported. Only fenced
+` ```yaml` blocks are detected.

--- a/docs/guide/yaml.md
+++ b/docs/guide/yaml.md
@@ -33,7 +33,7 @@ config = MDConverter(ServerConfig).parse_yaml(markdown)
     pip install md2pydantic[yaml]
     ```
 
-    An `ImportError` is raised at parse time if `pyyaml`
+    An `ExtractionError` is raised at parse time if `pyyaml`
     is not installed.
 
 !!! note

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# md2pydantic
+
+Extract structured data from messy Markdown into
+[Pydantic v2](https://docs.pydantic.dev/) models.
+
+Built for resilience against common LLM output quirks:
+triple-backtick wrappers, trailing prose, incomplete tables,
+malformed JSON, and more.
+
+## Features
+
+- **One-liner API** -- parse in a single call
+- **Markdown tables** -- pipe-delimited tables to model lists
+- **JSON blocks** -- fenced and inline, with recovery
+- **YAML blocks** -- fenced YAML code blocks
+- **Auto-detect** -- tries code blocks first, then tables
+- **Bool coercion** -- Yes/No/Y/N/true/false/on/off
+- **Null sentinels** -- N/A, NA, null, -, and empty cells
+- **Table selection** -- filter by heading or index
+- **Partial results** -- get valid rows even when some fail
+- **Lightweight** -- only depends on `pydantic>=2.0`
+
+## Installation
+
+```bash
+pip install md2pydantic
+```
+
+## Quick Taste
+
+```python
+from pydantic import BaseModel
+from md2pydantic import MDConverter
+
+class Product(BaseModel):
+    name: str
+    price: float
+    in_stock: bool
+
+md = """
+| name   | price | in_stock |
+|--------|-------|----------|
+| Widget | 9.99  | Yes      |
+| Gadget | 24.50 | No       |
+"""
+
+products = MDConverter(Product).parse_tables(md)
+# [Product(name='Widget', price=9.99, in_stock=True),
+#  Product(name='Gadget', price=24.5, in_stock=False)]
+```
+
+## Next Steps
+
+- [Getting Started](getting-started.md) -- installation
+  and a complete walkthrough
+- [User Guide](guide/index.md) -- format-specific examples
+- [API Reference](api.md) -- full method signatures

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: md2pydantic
+site_url: https://felipemorandini.github.io/md2pydantic/
+site_description: Extract structured data from messy Markdown into Pydantic v2 models
+site_author: Felipe Pires Morandini
+
+repo_name: FelipeMorandini/md2pydantic
+repo_url: https://github.com/FelipeMorandini/md2pydantic
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.tabs.link
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets:
+      base_path: "."
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - User Guide:
+      - Overview: guide/index.md
+      - Markdown Tables: guide/tables.md
+      - JSON Blocks: guide/json.md
+      - YAML Blocks: guide/yaml.md
+      - Auto-Detect: guide/auto-detect.md
+      - Table Selection: guide/table-selection.md
+      - Null Sentinels: guide/null-sentinels.md
+      - Error Handling: guide/error-handling.md
+      - Partial Results: guide/partial-results.md
+  - API Reference: api.md
+  - Supported Formats: formats.md
+  - Architecture: architecture.md
+  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
 pandas = ["pandas>=2.0.0"]
 markdown = ["marko>=2.0.0"]
 yaml = ["pyyaml>=6.0"]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=6.0.0",
@@ -42,6 +46,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/felipemorandini/md2pydantic"
+Documentation = "https://felipemorandini.github.io/md2pydantic/"
 Repository = "https://github.com/felipemorandini/md2pydantic"
 Issues = "https://github.com/felipemorandini/md2pydantic/issues"
 


### PR DESCRIPTION
## Summary

- Complete MkDocs documentation site with Material theme (dark/light toggle)
- 16 pages: home, getting started, 9 user guide topics, API reference, formats, architecture, changelog
- GitHub Actions workflow for automatic deployment to GitHub Pages on push to main
- `docs` optional dependency group (`mkdocs`, `mkdocs-material`)
- `mkdocs build --strict` passes with zero warnings

Closes #14

## Setup required after merge

Enable GitHub Pages with "GitHub Actions" source:
Settings > Pages > Source > GitHub Actions

## Test plan

- [x] `uv run mkdocs build --strict` — zero warnings
- [x] All 506 tests still pass
- [x] ruff and mypy clean